### PR TITLE
Fatura Oluşturma

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ $fatura_detaylari  = [
 "paraBirimi"  =>  "TRY",
 "dovzTLkur"  =>  "0",
 "faturaTipi"  =>  "SATIS",
+"hangiTip"  =>  "5000/30000",
 "vknTckn"  =>  "11111111111",
 "aliciUnvan"  =>  "FURKAN KADIOGLU",
 "aliciAdi"  =>  "FURKAN",

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ $fatura_detaylari["malHizmetTable"][] = [
 "iskontoNedeni"  =>  "",
 "malHizmetTutari"  =>  "99",
 "kdvOrani"  =>  18,
+"vergiOrani" => 0,
 "kdvTutari"  =>  "15.12",
 "vergininKdvTutari"  =>  "0"
 ];

--- a/src/InvoiceManager.php
+++ b/src/InvoiceManager.php
@@ -324,7 +324,7 @@ class InvoiceManager {
     {
         if(isset($jsonData["error"]))
         {
-            throw new ApiException("Bir hata oluştu! \t \n".print_r($jsonData));
+            throw new ApiException("Bir hata oluştu! \t \n".print_r($jsonData, true));
         }
     }
 

--- a/src/InvoiceManager.php
+++ b/src/InvoiceManager.php
@@ -446,7 +446,7 @@ class InvoiceManager
         $body = $this->sendRequestAndGetBody(self::DISPATCH_PATH, $parameters);
         $this->checkError($body);
 
-        if ($body["data"] != "Faturanız başarıyla taslaklara eklenmiştir.") {
+        if ($body["data"] != "Fatura başarıyla taslaklara eklenmiştir.") {
             throw new ApiException("Fatura oluşturulamadı.");
         }
 

--- a/src/Models/Invoice.php
+++ b/src/Models/Invoice.php
@@ -19,6 +19,7 @@ class Invoice
     protected $currency;
     protected $currencyRate;
     protected $invoiceType;
+    protected $whichType;
     protected $taxOrIdentityNumber;
     protected $invoiceAcceptorTitle;
     protected $invoiceAcceptorName;
@@ -78,6 +79,7 @@ class Invoice
         $this->currency = isset($data["paraBirimi"]) ? $data["paraBirimi"] : "";
         $this->currencyRate = isset($data["dovzTLkur"]) ? $data["dovzTLkur"] : "";
         $this->invoiceType = isset($data["faturaTipi"]) ? $data["faturaTipi"] : "";
+        $this->whichType = isset($data["hangiTip"]) ? $data["hangiTip"] : "5000/30000";
         $this->taxOrIdentityNumber = isset($data["vknTckn"]) ? $data["vknTckn"] : "11111111111";
         $this->invoiceAcceptorTitle = isset($data["aliciUnvan"]) ? $data["aliciUnvan"] : "";
         $this->invoiceAcceptorName = isset($data["aliciAdi"]) ? $data["aliciAdi"] : "";
@@ -134,6 +136,7 @@ class Invoice
         $this->currency = isset($data["currency"]) ? $data["currency"] : "";
         $this->currencyRate = isset($data["currencyRate"]) ? $data["currencyRate"] : "";
         $this->invoiceType = isset($data["invoiceType"]) ? $data["invoiceType"] : "";
+        $this->whichType = isset($data["whichType"]) ? $data["whichType"] : "5000/30000";
         $this->taxOrIdentityNumber = isset($data["taxOrIdentityNumber"]) ? $data["taxOrIdentityNumber"] : "11111111111";
         $this->invoiceAcceptorTitle = isset($data["invoiceAcceptorTitle"]) ? $data["invoiceAcceptorTitle"] : "";
         $this->invoiceAcceptorName = isset($data["invoiceAcceptorName"]) ? $data["invoiceAcceptorName"] : "";
@@ -217,6 +220,7 @@ class Invoice
             "paraBirimi" => $this->currency,
             "dovzTLkur" => $this->currencyRate,
             "faturaTipi" => $this->invoiceType,
+            "hangiTip" =>  $this->whichType,
             "vknTckn" => $this->taxOrIdentityNumber,
             "aliciUnvan" => $this->invoiceAcceptorTitle,
             "aliciAdi" => $this->invoiceAcceptorName,
@@ -435,6 +439,28 @@ class Invoice
     public function setInvoiceType($invoiceType)
     {
         $this->invoiceType = $invoiceType;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of whichType
+     * 
+     * @return string
+     */
+    public function getWhichType()
+    {
+        return $this->whichType;
+    }
+
+    /**
+     * Set the value of invoiceType
+     *
+     * @return  self
+     */
+    public function setWhichType($whichType)
+    {
+        $this->whichType = $whichType;
 
         return $this;
     }


### PR DESCRIPTION
### Düzenleme 1:

Sanırım GIB, fatura oluşturduktan sonraki cevap mesajını değiştirmiş.
Bugün itibariyle faturayı taslaklara ekledikten sonra dönen json verisi şöyle:

`{"data":"Fatura başarıyla taslaklara eklenmiştir.","metadata":{"optime":"20200520134926+0300"}}`

Ancak InvoiceManager.php'nin 450. satırı şu şekilde:

```
if($body["data"] != "Fatura**nız** başarıyla taslaklara eklenmiştir.")
        {
            throw new ApiException("Fatura oluşturulamadı.");
        }
```
---
### Düzenleme 2:

Fatura oluşturma parametlerine hangiTip isminde bir parametre gelmiş ve değeri varsaılan olarak "5000/30000" geliyor. Invoice.php içerisinde bu parametreyi ekledim.
Kendi kullandığım sistemde çalıştı ancak test ederseniz sevinirim.

---
### Düzenleme 3: 

malHizmetTable bölümünde her kalem için vergiOrani diye bir parametre gelmiş. Bunu Readme.md dosyasına ekledim.

---
### Olası Bir Problem

Sanırım bazı parametrelerin tipi değişmiş. Örneğin kdvOranı eskiden integer/float iken şimdi string olarak gidiyor. Aynı şekilde bazı tutar parametreleri de değişmiş. Kendi sistemimde GIB'in gönderdiği şekle çevirdim ancak tutarların string olması zorunlu mu, float olarak gönderilse sorun çıkar mı test edemedim. Test edersem yeni bir PR açarım. Ancak şu an çalıştığı için GIB'e uymayı uygun görüyorum.

Bununla ilgili readme.md dosyasında değişiklik yapmadım.