### PR TITLE
SMS Doğrulama Hatası Çözümü

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "homepage": "https://github.com/furkankadioglu/efatura",
     "license": "MIT",
-    "version": "1.9.2",
+    "version": "1.9.3",
     "authors": [
         {
             "name": "Furkan Kadıoğlu",

--- a/src/InvoiceManager.php
+++ b/src/InvoiceManager.php
@@ -728,6 +728,34 @@ class InvoiceManager
     }
 
     /**
+     * Initialize SMS Verification
+     *
+     * @return boolean
+     */
+     
+     private function initializeSMSVerification()
+     {
+        $parameters = [
+            "cmd" => "EARSIV_PORTAL_TELEFONNO_SORGULA",
+            "callid" => Uuid::uuid1()->toString(),
+            "pageName" => "RG_BASITTASLAKLAR",
+            "token" => $this->token,
+            "jp" => "{}",
+        ];
+
+        $body = $this->sendRequestAndGetBody(self::DISPATCH_PATH, $parameters);
+        $this->checkError($body);
+
+        if(!isset($body["data"]["telefon"]))
+        {
+            return false;
+        }
+
+        return true;
+    }
+    
+    
+    /**
      * Send user informations data
      *
      * @param string $phoneNumber
@@ -735,9 +763,11 @@ class InvoiceManager
      */
     public function sendSMSVerification($phoneNumber)
     {
+        $this->initializeSMSVerification();
+        
         $data = [
             "CEPTEL" => $phoneNumber,
-            "KTEL" => false,
+            "KCEPTEL" => false,
             "TIP" => ""
         ];
 


### PR DESCRIPTION
SMS doğrulamasından önce sunucuya bir tane istek yapmak gerekiyor. Bu istek yapılmadığı için SMS doğrulamasında kullanılan operasyon id'si gelmiyor ve hataya düşüyor. SMS gönderimi öncesine bu isteği yapan bir kod parçası ekledim.